### PR TITLE
Use ansible infrastructure repo for initial container setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ sudo: required
 services:
   - docker
 
-# Upgrade to latest docker-engine
-before_install:
-  - sudo apt-get update -qq
-  - sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" docker-engine
-
 install:
   - pip install -U docker-py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+cache: pip
+sudo: required
+services:
+  - docker
+
+# Upgrade to latest docker-engine
+before_install:
+  - sudo apt-get update -qq
+  - sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" docker-engine
+
+install:
+  - pip install -U docker-py
+
+script:
+    - ./test.sh

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To run the Docker images start a postgres DB:
 
 Then either run a single all-in-one master:
 
-    docker run -d --name omero-master --link postgres:db -e DBUSER=postgres
+    docker run -d --name omero-master --link postgres:db -e DBUSER=postgres \
         -e DBPASS=postgres -e DBNAME=postgres -p 4063:4063 -p 4064:4064 \
         openmicroscopy/omero-grid master
 
@@ -74,6 +74,21 @@ Exposed ports
 
 - `omero-grid`: 4061, 4063, 4064
 - `omero-grid-web`: 8080
+
+
+Example with named volumes
+--------------------------
+
+    docker volume create --name omero-db
+    docker volume create --name omero-data
+
+    docker run -d --name postgres -e POSTGRES_PASSWORD=postgres \
+        -v omero-db:/var/lib/postgresql/data postgres
+    docker run -d --name omero-master --link postgres:db -e DBUSER=postgres \
+        -e DBPASS=postgres -e DBNAME=postgres -v omero-data:/OMERO \
+        -p 4063:4063 -p 4064:4064 openmicroscopy/omero-grid master
+    docker run -d --name omero-web --link omero-master:master -p 8080:8080 \
+        openmicroscopy/omero-grid-web
 
 
 Running without links

--- a/omero-grid-web/Dockerfile
+++ b/omero-grid-web/Dockerfile
@@ -4,18 +4,19 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 # TODO: Use separate Nginx container
 
 RUN yum -y install epel-release && \
-    curl -o /etc/yum.repos.d/zeroc-ice-el7.repo \
-        http://download.zeroc.com/Ice/3.5/el7/zeroc-ice-el7.repo && \
-    yum -y install http://nginx.org/packages/centos/7/noarch/RPMS/nginx-release-centos-7-0.el7.ngx.noarch.rpm && \
-    yum -y install \
-        unzip wget \
-        ice ice-python \
-        python-pip \
-        numpy scipy python-matplotlib python-pillow python-tables \
-        nginx python-gunicorn && \
-    yum clean all
+    yum -y install ansible unzip
 
-RUN pip install 'Django<1.9' omego
+ARG INFRASTRUCTURE_BRANCH=ansible-2.2
+RUN cd /opt && \
+    curl -L -o infrastructure.zip https://github.com/manics/infrastructure/archive/${INFRASTRUCTURE_BRANCH}.zip && \
+    unzip infrastructure.zip && \
+    rm infrastructure.zip
+ADD omero-grid-web-deps.yml /opt/infrastructure-${INFRASTRUCTURE_BRANCH}/ansible
+
+RUN cd /opt/infrastructure-${INFRASTRUCTURE_BRANCH}/ansible && \
+    ansible-playbook omero-grid-web-deps.yml
+
+RUN pip install omego
 
 RUN useradd omero && \
     rm /etc/nginx/conf.d/* && \

--- a/omero-grid-web/Dockerfile
+++ b/omero-grid-web/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 # TODO: Use separate Nginx container
 
 RUN yum -y install epel-release && \
-    yum -y install ansible unzip
+    yum -y install ansible git unzip
 
 ARG INFRASTRUCTURE_BRANCH=master
 RUN cd /opt && \
@@ -14,6 +14,7 @@ RUN cd /opt && \
 ADD omero-grid-web-deps.yml /opt/infrastructure-${INFRASTRUCTURE_BRANCH}/ansible
 
 RUN cd /opt/infrastructure-${INFRASTRUCTURE_BRANCH}/ansible && \
+    ansible-galaxy install -r requirements.yml && \
     ansible-playbook omero-grid-web-deps.yml
 
 RUN pip install omego

--- a/omero-grid-web/Dockerfile
+++ b/omero-grid-web/Dockerfile
@@ -6,9 +6,9 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 RUN yum -y install epel-release && \
     yum -y install ansible unzip
 
-ARG INFRASTRUCTURE_BRANCH=ansible-2.2
+ARG INFRASTRUCTURE_BRANCH=master
 RUN cd /opt && \
-    curl -L -o infrastructure.zip https://github.com/manics/infrastructure/archive/${INFRASTRUCTURE_BRANCH}.zip && \
+    curl -L -o infrastructure.zip https://github.com/openmicroscopy/infrastructure/archive/${INFRASTRUCTURE_BRANCH}.zip && \
     unzip infrastructure.zip && \
     rm infrastructure.zip
 ADD omero-grid-web-deps.yml /opt/infrastructure-${INFRASTRUCTURE_BRANCH}/ansible

--- a/omero-grid-web/Dockerfile
+++ b/omero-grid-web/Dockerfile
@@ -4,16 +4,12 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 # TODO: Use separate Nginx container
 
 RUN yum -y install epel-release && \
-    yum -y install ansible git unzip
+    yum -y install ansible
 
-ARG INFRASTRUCTURE_BRANCH=master
-RUN cd /opt && \
-    curl -L -o infrastructure.zip https://github.com/openmicroscopy/infrastructure/archive/${INFRASTRUCTURE_BRANCH}.zip && \
-    unzip infrastructure.zip && \
-    rm infrastructure.zip
-ADD omero-grid-web-deps.yml /opt/infrastructure-${INFRASTRUCTURE_BRANCH}/ansible
+RUN mkdir /opt/infrastructure
+ADD omero-grid-web-deps.yml requirements.yml /opt/infrastructure/
 
-RUN cd /opt/infrastructure-${INFRASTRUCTURE_BRANCH}/ansible && \
+RUN cd /opt/infrastructure && \
     ansible-galaxy install -r requirements.yml && \
     ansible-playbook omero-grid-web-deps.yml
 

--- a/omero-grid-web/omero-grid-web-deps.yml
+++ b/omero-grid-web/omero-grid-web-deps.yml
@@ -1,0 +1,8 @@
+- hosts: localhost
+  roles:
+  - role: nginx
+  - role: omero-web-runtime
+  vars:
+  - ice_version: "3.6"
+  # TODO: hack to prevent nginx bveing restarted (requires systemd)
+  - nginx_keep_default_configs: True

--- a/omero-grid-web/omero-grid-web-deps.yml
+++ b/omero-grid-web/omero-grid-web-deps.yml
@@ -1,7 +1,7 @@
 - hosts: localhost
   roles:
-  - role: nginx
-  - role: omero-web-runtime
+  - role: openmicroscopy.nginx
+  - role: openmicroscopy.omero-web-runtime
   vars:
   - ice_version: "3.6"
   # TODO: hack to prevent nginx bveing restarted (requires systemd)

--- a/omero-grid-web/omero-grid-web-deps.yml
+++ b/omero-grid-web/omero-grid-web-deps.yml
@@ -4,5 +4,5 @@
   - role: openmicroscopy.omero-web-runtime
   vars:
   - ice_version: "3.6"
-  # TODO: hack to prevent nginx bveing restarted (requires systemd)
+  # TODO: hack to prevent nginx being restarted (requires systemd)
   - nginx_keep_default_configs: True

--- a/omero-grid-web/requirements.yml
+++ b/omero-grid-web/requirements.yml
@@ -1,0 +1,19 @@
+# External Ansible roles required by this repository
+
+- src: openmicroscopy.basedeps
+  version: 1.0.0
+
+- src: openmicroscopy.ice
+  version: 1.0.0
+
+- src: openmicroscopy.nginx
+  version: 1.0.0
+
+- src: openmicroscopy.omero-python-deps
+  version: 1.0.0
+
+- src: openmicroscopy.omero-web-runtime
+  version: 1.0.0
+
+- src: openmicroscopy.redis
+  version: 1.0.0

--- a/omero-grid/Dockerfile
+++ b/omero-grid/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 
 RUN yum -y install epel-release && \
-    yum -y install ansible unzip
+    yum -y install ansible git unzip
 
 ARG INFRASTRUCTURE_BRANCH=master
 RUN cd /opt && \
@@ -13,6 +13,7 @@ RUN cd /opt && \
 ADD omero-grid-deps.yml /opt/infrastructure-${INFRASTRUCTURE_BRANCH}/ansible
 
 RUN cd /opt/infrastructure-${INFRASTRUCTURE_BRANCH}/ansible && \
+    ansible-galaxy install -r requirements.yml && \
     ansible-playbook omero-grid-deps.yml
 
 RUN pip install omego

--- a/omero-grid/Dockerfile
+++ b/omero-grid/Dockerfile
@@ -1,17 +1,19 @@
 FROM centos:centos7
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
+
 RUN yum -y install epel-release && \
-    curl -o /etc/yum.repos.d/zeroc-ice-el7.repo \
-        http://download.zeroc.com/Ice/3.5/el7/zeroc-ice-el7.repo && \
-    yum -y install \
-        unzip wget patch \
-        java-1.8.0-openjdk \
-        ice ice-python ice-servers \
-        python-pip \
-        numpy scipy python-matplotlib python-pillow python-tables \
-        postgresql && \
-    yum clean all
+    yum -y install ansible unzip
+
+ARG INFRASTRUCTURE_BRANCH=ansible-2.2
+RUN cd /opt && \
+    curl -L -o infrastructure.zip https://github.com/manics/infrastructure/archive/${INFRASTRUCTURE_BRANCH}.zip && \
+    unzip infrastructure.zip && \
+    rm infrastructure.zip
+ADD omero-grid-deps.yml /opt/infrastructure-${INFRASTRUCTURE_BRANCH}/ansible
+
+RUN cd /opt/infrastructure-${INFRASTRUCTURE_BRANCH}/ansible && \
+    ansible-playbook omero-grid-deps.yml
 
 RUN pip install omego
 

--- a/omero-grid/Dockerfile
+++ b/omero-grid/Dockerfile
@@ -3,16 +3,12 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 
 RUN yum -y install epel-release && \
-    yum -y install ansible git unzip
+    yum -y install ansible
 
-ARG INFRASTRUCTURE_BRANCH=master
-RUN cd /opt && \
-    curl -L -o infrastructure.zip https://github.com/openmicroscopy/infrastructure/archive/${INFRASTRUCTURE_BRANCH}.zip && \
-    unzip infrastructure.zip && \
-    rm infrastructure.zip
-ADD omero-grid-deps.yml /opt/infrastructure-${INFRASTRUCTURE_BRANCH}/ansible
+RUN mkdir /opt/infrastructure
+ADD omero-grid-deps.yml requirements.yml /opt/infrastructure/
 
-RUN cd /opt/infrastructure-${INFRASTRUCTURE_BRANCH}/ansible && \
+RUN cd /opt/infrastructure && \
     ansible-galaxy install -r requirements.yml && \
     ansible-playbook omero-grid-deps.yml
 

--- a/omero-grid/Dockerfile
+++ b/omero-grid/Dockerfile
@@ -5,9 +5,9 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 RUN yum -y install epel-release && \
     yum -y install ansible unzip
 
-ARG INFRASTRUCTURE_BRANCH=ansible-2.2
+ARG INFRASTRUCTURE_BRANCH=master
 RUN cd /opt && \
-    curl -L -o infrastructure.zip https://github.com/manics/infrastructure/archive/${INFRASTRUCTURE_BRANCH}.zip && \
+    curl -L -o infrastructure.zip https://github.com/openmicroscopy/infrastructure/archive/${INFRASTRUCTURE_BRANCH}.zip && \
     unzip infrastructure.zip && \
     rm infrastructure.zip
 ADD omero-grid-deps.yml /opt/infrastructure-${INFRASTRUCTURE_BRANCH}/ansible

--- a/omero-grid/omero-grid-deps.yml
+++ b/omero-grid/omero-grid-deps.yml
@@ -1,7 +1,10 @@
 - hosts: localhost
   roles:
-  - role: omero-runtime
-  - role: postgresql
+  - role: openmicroscopy.basedeps
+  - role: openmicroscopy.java
+  - role: openmicroscopy.omero-python-deps
+  - role: openmicroscopy.ice
+  - role: openmicroscopy.postgresql
     postgresql_install_server: False
   vars:
   - ice_version: "3.6"

--- a/omero-grid/omero-grid-deps.yml
+++ b/omero-grid/omero-grid-deps.yml
@@ -1,0 +1,7 @@
+- hosts: localhost
+  roles:
+  - role: omero-runtime
+  - role: postgresql
+    postgresql_install_server: False
+  vars:
+  - ice_version: "3.6"

--- a/omero-grid/requirements.yml
+++ b/omero-grid/requirements.yml
@@ -7,8 +7,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.java
-  # TODO: tag
-  version: master
+  version: 1.0.0
 
 - src: openmicroscopy.omero-python-deps
   version: 1.0.0

--- a/omero-grid/requirements.yml
+++ b/omero-grid/requirements.yml
@@ -1,0 +1,17 @@
+# External Ansible roles required by this repository
+
+- src: openmicroscopy.basedeps
+  version: 1.0.0
+
+- src: openmicroscopy.ice
+  version: 1.0.0
+
+- src: openmicroscopy.java
+  # TODO: tag
+  version: master
+
+- src: openmicroscopy.omero-python-deps
+  version: 1.0.0
+
+- src: openmicroscopy.postgresql
+  version: 1.0.0


### PR DESCRIPTION
This uses Ansible from EPEL (version 2.2), and therefore requires:
--depends-on https://github.com/openmicroscopy/infrastructure/pull/221

The two Docker containers can be built directly with the default arguments, `build.py` is provided for convenience when you want to pass additional parameters during a manual build.
- https://hub.docker.com/r/manics/omero-grid/
- https://hub.docker.com/r/manics/omero-grid-web/

Also re-adds `.travis.yml`