### PR TITLE
5.3: load requirements file (fix #3)

### DIFF
--- a/omero-grid-web/Dockerfile
+++ b/omero-grid-web/Dockerfile
@@ -46,7 +46,8 @@ ADD run.sh /home/omero/
 
 # TODO: Remove me once the role is updated.
 USER root
-RUN pip install -r /home/omero/OMERO.server/share/web/requirements-py27.txt
+ENV OMERO_REQUIREMENTS_FILE /home/omero/OMERO.server/share/web/requirements-py27.txt
+RUN test -f $OMERO_REQUIREMENTS_FILE && pip install -r $OMERO_REQUIREMENTS_FILE
 USER omero
 
 EXPOSE 8080

--- a/omero-grid-web/Dockerfile
+++ b/omero-grid-web/Dockerfile
@@ -44,6 +44,11 @@ RUN mkdir -p nginx/cache nginx/log nginx/run nginx/temp OMERO.server/var
 
 ADD run.sh /home/omero/
 
+# TODO: Remove me once the role is updated.
+USER root
+RUN pip install -r /home/omero/OMERO.server/share/web/requirements-py27.txt
+USER omero
+
 EXPOSE 8080
 VOLUME ["/home/omero/nginx", "/home/omero/OMERO.server/var"]
 


### PR DESCRIPTION
Once downloads.openmicroscopy.org/latest/omero starting redirecting
to 5.3 rather than 5.2, the `pipelines` library was missing for web.
This adds a last-minute call to `pip install -r` in order to install
dependencies globally. Longer-term, the playbook version should have
installed all dependencies installed.

cc: @heidricha 