### PR TITLE
Streamline omero-grid build and add OMEROPASS variable for entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Then either run a single all-in-one master:
 
     docker run -d --name omero-master --link postgres:db -e DBUSER=postgres \
         -e DBPASS=postgres -e DBNAME=postgres -p 4063:4063 -p 4064:4064 \
-        openmicroscopy/omero-grid master
+        -e ROOTPASS=omero openmicroscopy/omero-grid master
 
 Or run a master and one or more slaves, the configuration must be provided to the master node.
 For example, to run two Processors on separate slaves and all other servers on master:

--- a/omero-grid-web/Dockerfile
+++ b/omero-grid-web/Dockerfile
@@ -3,51 +3,52 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 # TODO: Use separate Nginx container
 
-RUN yum -y install epel-release && \
-    yum -y install ansible
+ARG OMERO_VERSION=latest
+ARG CI_SERVER
+ARG OMEGO_ARGS
 
-RUN mkdir /opt/infrastructure
-ADD omero-grid-web-deps.yml requirements.yml /opt/infrastructure/
+WORKDIR /home/omero
 
-RUN cd /opt/infrastructure && \
-    ansible-galaxy install -r requirements.yml && \
-    ansible-playbook omero-grid-web-deps.yml
+ADD omero-grid-web-deps.yml requirements.yml run.sh /home/omero/
 
-RUN pip install omego
+# TODO: Remove requirements install once the role is updated.
+ENV OMERO_REQUIREMENTS_FILE OMERO.server/share/web/requirements-py27.txt
 
-RUN useradd omero && \
-    rm /etc/nginx/conf.d/* && \
-    sed -i -r -e 's|/var/([^/]+)(/nginx)?/|/home/omero/nginx/\1/|' \
-        -e '/^user/s/^/#/' /etc/nginx/nginx.conf && \
-    rm -rf /var/cache/nginx /var/log/nginx && \
-    chown -R omero /etc/nginx/conf.d && \
-    ln -sf /home/omero/nginx/cache /var/cache/nginx && \
-    ln -sf /home/omero/nginx/log /var/log/nginx
+RUN yum -y install epel-release \
+    && yum -y install ansible \
+    && ansible-galaxy install -r requirements.yml \
+    && ansible-playbook omero-grid-web-deps.yml \
+    && useradd omero \
+    && pip install omego \
+    && bash -c 'CI=; if [ -n "$CI_SERVER" ]; then CI="--ci $CI_SERVER"; fi; \
+                omego download python $CI --release $OMERO_VERSION $OMEGO_ARGS' \
+    && rm OMERO.py-*.zip \
+    && ln -s OMERO.py-*/ OMERO.server \
+    && rm /etc/nginx/conf.d/* \
+    && sed -i -r -e 's|/var/([^/]+)(/nginx)?/|/home/omero/nginx/\1/|' \
+           -e '/^user/s/^/#/' /etc/nginx/nginx.conf \
+    && rm -rf /var/cache/nginx /var/log/nginx \
+    # Must create OMERO.server/var because it's marked as a volume and will
+    # otherwise default to root ownership
+    && mkdir -p nginx/cache nginx/log nginx/run nginx/temp OMERO.server/var \
+    && ln -sf /home/omero/nginx/cache /var/cache/nginx \
+    && ln -sf /home/omero/nginx/log /var/log/nginx \
+    # TODO: Remove requirements install once the role is updated.
+    && test -f $OMERO_REQUIREMENTS_FILE && pip install -r $OMERO_REQUIREMENTS_FILE \
+    && chown omero:omero -R .
+
+# Unavoidable hack as it is impossible to run omero as root
+USER omero
+RUN OMERO.server/bin/omero web config --http 8080 nginx > omero-web.conf
+USER root
+RUN mv omero-web.conf /etc/nginx/conf.d/omero-web.conf \
+    && chown root:root /etc/nginx/conf.d/omero-web.conf
+
 # TODO: Use docker logging instead of log files?
 # https://github.com/nginxinc/docker-nginx/blob/master/Dockerfile
     #ln -sf /dev/stdout /var/log/nginx/access.log && \
     #ln -sf /dev/stderr /var/log/nginx/error.log && \
 
-ARG OMERO_VERSION=latest
-ARG CI_SERVER
-ARG OMEGO_ARGS
-
-USER omero
-WORKDIR /home/omero
-RUN bash -c 'CI=; if [ -n "$CI_SERVER" ]; then CI="--ci $CI_SERVER"; fi; \
-    omego download python $CI --release $OMERO_VERSION $OMEGO_ARGS && \
-        rm OMERO.py-*.zip && \
-        ln -s OMERO.py-*/ OMERO.server'
-# Must create OMERO.server/var because it's marked as a volume and will
-# otherwise default to root ownership
-RUN mkdir -p nginx/cache nginx/log nginx/run nginx/temp OMERO.server/var
-
-ADD run.sh /home/omero/
-
-# TODO: Remove me once the role is updated.
-USER root
-ENV OMERO_REQUIREMENTS_FILE /home/omero/OMERO.server/share/web/requirements-py27.txt
-RUN test -f $OMERO_REQUIREMENTS_FILE && pip install -r $OMERO_REQUIREMENTS_FILE
 USER omero
 
 EXPOSE 8080

--- a/omero-grid-web/run.sh
+++ b/omero-grid-web/run.sh
@@ -11,7 +11,7 @@ omero=/home/omero/OMERO.server/bin/omero
 
 MASTER_ADDR=${MASTER_ADDR:-}
 if [ -z "$MASTER_ADDR" ]; then
-    MASTER_ADDR=${MASTER_PORT_4064_TCP_ADDR:-}
+    MASTER_ADDR=master
 fi
 if [ -n "$MASTER_ADDR" ]; then
     $omero config set omero.web.server_list "[[\"$MASTER_ADDR\", 4064, \"omero\"]]"
@@ -25,13 +25,6 @@ if stat -t /config/* > /dev/null 2>&1; then
         echo "Loading $f"
         $omero load "$f"
     done
-fi
-
-mkdir -p /home/omero/nginx/cache /home/omero/nginx/log /home/omero/nginx/temp
-NGINX_OMERO=/etc/nginx/conf.d/omero-web.conf
-if [ ! -f $NGINX_OMERO ]; then
-    echo "Creating $NGINX_OMERO"
-    $omero web config --http 8080 nginx > $NGINX_OMERO
 fi
 
 echo "Starting OMERO.web"

--- a/omero-grid/Dockerfile
+++ b/omero-grid/Dockerfile
@@ -12,7 +12,6 @@ ADD omero-grid-deps.yml requirements.yml slave.cfg run.sh process_defaultxml.py 
 RUN yum -y install epel-release \
     && yum -y install ansible \
     && ansible-galaxy install -r requirements.yml \
-    && ansible-galaxy install -r requirements.yml \
     && ansible-playbook omero-grid-deps.yml \
     && pip install omego \
     && useradd omero \

--- a/omero-grid/Dockerfile
+++ b/omero-grid/Dockerfile
@@ -1,44 +1,36 @@
 FROM centos:centos7
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
-
-RUN yum -y install epel-release && \
-    yum -y install ansible
-
-RUN mkdir /opt/infrastructure
-ADD omero-grid-deps.yml requirements.yml /opt/infrastructure/
-
-RUN cd /opt/infrastructure && \
-    ansible-galaxy install -r requirements.yml && \
-    ansible-playbook omero-grid-deps.yml
-
-RUN pip install omego
-
-RUN useradd omero && \
-    mkdir /OMERO && \
-    chown omero /OMERO
-
 ARG OMERO_VERSION=latest
 ARG CI_SERVER
 ARG OMEGO_ARGS
 
-USER omero
 WORKDIR /home/omero
+
+ADD omero-grid-deps.yml requirements.yml slave.cfg run.sh process_defaultxml.py /home/omero/
+
+RUN yum -y install epel-release \
+    && yum -y install ansible \
+    && ansible-galaxy install -r requirements.yml \
+    && ansible-galaxy install -r requirements.yml \
+    && ansible-playbook omero-grid-deps.yml \
+    && pip install omego \
+    && useradd omero \
+    && chown omero:omero -R . \
+    # https://github.com/docker/docker/issues/2259#issuecomment-48286811
+    && mkdir /OMERO \
+    # Ensure /OMERO is owned by the omero user
+    && chown omero:omero -R /OMERO
+
+USER omero
+
 RUN bash -c 'CI=; if [ -n "$CI_SERVER" ]; then CI="--ci $CI_SERVER"; fi; \
-    omego download server $CI --release $OMERO_VERSION $OMEGO_ARGS && \
-        rm OMERO.server-*.zip && \
-        ln -s OMERO.server-*/ OMERO.server'
-
-# default.xml may be modified at runtime for a multinode configuration
-RUN cp OMERO.server/etc/templates/grid/default.xml \
-    OMERO.server/etc/templates/grid/default.xml.orig
-
-ADD slave.cfg /home/omero/OMERO.server/etc/templates/
-ADD run.sh process_defaultxml.py /home/omero/
+    omego download server $CI --release $OMERO_VERSION $OMEGO_ARGS' \
+    && rm OMERO.server-*.zip \
+    && ln -s OMERO.server-*/ OMERO.server \
+    # default.xml may be modified at runtime for a multinode configuration
+    && cp OMERO.server/etc/templates/grid/default.xml OMERO.server/etc/templates/grid/default.xml.orig
 
 EXPOSE 4061 4063 4064
-
 VOLUME ["/OMERO", "/home/omero/OMERO.server/var"]
-
-# Set the default command to run when starting the container
 ENTRYPOINT ["/home/omero/run.sh"]

--- a/omero-grid/Dockerfile
+++ b/omero-grid/Dockerfile
@@ -25,7 +25,7 @@ RUN yum -y install epel-release \
 USER omero
 
 RUN bash -c 'CI=; if [ -n "$CI_SERVER" ]; then CI="--ci $CI_SERVER"; fi; \
-    omego download server $CI --release $OMERO_VERSION $OMEGO_ARGS' \
+             omego download server $CI --release $OMERO_VERSION $OMEGO_ARGS' \
     && rm OMERO.server-*.zip \
     && ln -s OMERO.server-*/ OMERO.server \
     # default.xml may be modified at runtime for a multinode configuration

--- a/omero-grid/run.sh
+++ b/omero-grid/run.sh
@@ -33,6 +33,7 @@ elif [ "$TARGET" = master ]; then
     DBUSER=${DBUSER:-omero}
     DBNAME=${DBNAME:-omero}
     DBPASS=${DBPASS:-omero}
+    ROOTPASS=${ROOTPASS:-omero}
     MASTER_IP=$(hostname -i)
 
     export PGPASSWORD="$DBPASS"
@@ -58,7 +59,7 @@ elif [ "$TARGET" = master ]; then
         DBCMD=init
     }
     omego db $DBCMD --dbhost "$DBHOST" --dbuser "$DBUSER" --dbname "$DBNAME" \
-        --dbpass "$DBPASS" --serverdir=OMERO.server
+        --dbpass "$DBPASS" --rootpass "$ROOTPASS" --serverdir=OMERO.server
 
     $omero config set omero.db.host "$DBHOST"
     $omero config set omero.db.user "$DBUSER"

--- a/omero-grid/run.sh
+++ b/omero-grid/run.sh
@@ -24,11 +24,7 @@ elif [ "$TARGET" = master ]; then
 
     DBHOST=${DBHOST:-}
     if [ -z "$DBHOST" ]; then
-        DBHOST=${DB_PORT_5432_TCP_ADDR:-}
-    fi
-    if [ -z "$DBHOST" ]; then
-        echo "ERROR: Postgres host address not found"
-        exit 2
+        DBHOST=db
     fi
     DBUSER=${DBUSER:-omero}
     DBNAME=${DBNAME:-omero}
@@ -80,12 +76,9 @@ elif [ "$TARGET" = master ]; then
 else
     MASTER_ADDR=${MASTER_ADDR:-}
     if [ -z "$MASTER_ADDR" ]; then
-        MASTER_ADDR=${MASTER_PORT_4061_TCP_ADDR:-}
+        MASTER_ADDR=master
     fi
-    if [ -z "$MASTER_ADDR" ]; then
-        echo "ERROR: Master address not found"
-        exit 2
-    fi
+
     SLAVE_ADDR=$(hostname -i)
 
     $omero config set omero.master.host "$MASTER_ADDR"


### PR DESCRIPTION
Reduce the number of layers in the build and simplify.

Allows configuration of the OMERO root password when running an `omero-grid` container.