### PR TITLE
Bump version of openmicroscopy.ice role

### DIFF
--- a/omero-grid-web/requirements.yml
+++ b/omero-grid-web/requirements.yml
@@ -4,7 +4,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.ice
-  version: 1.0.0
+  version: 2.1.1
 
 - src: openmicroscopy.nginx
   version: 1.0.0

--- a/omero-grid/requirements.yml
+++ b/omero-grid/requirements.yml
@@ -4,7 +4,7 @@
   version: 1.0.0
 
 - src: openmicroscopy.ice
-  version: 1.0.0
+  version: 2.1.1
 
 - src: openmicroscopy.java
   version: 1.0.0


### PR DESCRIPTION
Fix the ongoing build failures (see https://hub.docker.com/r/openmicroscopy/omero-grid/builds/bjfq39n8w3dcmp658nbb5k9/ and https://hub.docker.com/r/openmicroscopy/omero-grid-web/builds/bqrhpkte3fzt2ubymvbbcb5/) which have been fixed in the [Ansible Ice role](https://github.com/openmicroscopy/ansible-role-ice/pull/5).

NB: https://github.com/openmicroscopy/omero-grid-docker/pull/9 is included a large refactoring of this role but it on hold. In the interim, this PR should be validated by Travis and fix the Docker Hub failures.